### PR TITLE
refactor to class, fix types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export { createSaga, AddJobFn } from "./src/saga";
+export { Saga, AddJobFn } from "./src/saga";

--- a/src/saga.test.ts
+++ b/src/saga.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, mock, beforeAll } from "bun:test";
 import { z } from "zod";
-import { createSaga } from "./saga";
+import { Saga } from "./saga";
 import { runTaskListOnce, quickAddJob, TaskList, run } from "graphile-worker";
 import { Pool } from "pg";
 
@@ -22,7 +22,7 @@ describe("graphile-saga", () => {
   test("saga.getTaskList should return a task list with the initial task, all the steps, and the cancel steps", async () => {
     const sagaName = "test-get-task-list";
 
-    const saga = createSaga(sagaName, z.object({ name: z.string() }))
+    const saga = new Saga(sagaName, z.object({ name: z.string() }))
       .addStep({
         name: "step1",
         run: async () => {},
@@ -48,7 +48,7 @@ describe("graphile-saga", () => {
 
     const fn = mock(async () => {});
 
-    const saga = createSaga(sagaName, z.object({ name: z.string() })).addStep({
+    const saga = new Saga(sagaName, z.object({ name: z.string() })).addStep({
       name: "step1",
       run: fn,
     });
@@ -69,7 +69,7 @@ describe("graphile-saga", () => {
 
     const fn2 = mock(async (shouldBeResult1: string) => {});
 
-    const saga = createSaga(sagaName, z.object({ name: z.string() }))
+    const saga = new Saga(sagaName, z.object({ name: z.string() }))
       .addStep({
         name: "step1",
         run: async (initialPayload, priorResults, helpers) => {
@@ -113,7 +113,7 @@ describe("graphile-saga", () => {
       }
     );
 
-    const saga = createSaga(sagaName, z.string())
+    const saga = new Saga(sagaName, z.string())
       .addStep({
         name: "step1",
         run: async (initialPayload, priorResults, helpers) => {
@@ -164,7 +164,7 @@ describe("graphile-saga", () => {
       }
     );
 
-    const saga = createSaga(sagaName, z.string())
+    const saga = new Saga(sagaName, z.string())
       .addStep({
         name: "step1",
         run: async (initialPayload, priorResults, helpers) => {
@@ -223,7 +223,7 @@ describe("graphile-saga", () => {
       }
     );
 
-    const saga = createSaga(sagaName, z.string())
+    const saga = new Saga(sagaName, z.string())
       .addStep({
         name: "step1",
         run: async (initialPayload, priorResults, helpers) => {

--- a/src/saga.ts
+++ b/src/saga.ts
@@ -119,11 +119,16 @@ export class Saga<
   ) {}
 
   addStep<StepName extends string, StepResult>(
-    step: Step<PriorSteps, StepResult, StepName, InitialPayload>
+    step: Step<PriorSteps, StepResult, StepName, z.infer<InitialPayload>>
   ): Saga<
     SagaName,
     InitialPayload,
-    AddStepToPriorSteps<PriorSteps, StepName, StepResult, InitialPayload>
+    AddStepToPriorSteps<
+      PriorSteps,
+      StepName,
+      StepResult,
+      z.infer<InitialPayload>
+    >
   > {
     this.steps.push(step);
     return this as any;


### PR DESCRIPTION
I messed about a bit trying to fix the type issue I faced here: #1. I think that is fixed for me now. I also refactored to a class. This lets you store the `PriorResults` type in as a generic and update it as you call `.addStep` so you could do more fancy type stuff if you need. Also I fixed an issue where the payload of the `AddJobFn` type was unknown. So:

```ts
export const saga = new Saga("mySaga", z.object({ name: z.string() }))
.addStep({
    name: "step1",
    run: async (payload, priorResults, helpers) => {
        return 5;
    },
})
.addStep({
    name: "step2",
    run: async (payload, priorResults, helpers) => {
        return 10;
    },
    cancel: async (payload, priorResults, runResult, helpers) => {
        console.log("Cancelling step 2");
    },
});

const taskList = saga.getTaskList();

const addJob: SagaTolerantAddJobFn<typeof taskList> = async (name, payload) => {
    return {} as any;
};

addJob("mySaga", 5); // should show type error
```
